### PR TITLE
Update .travis.yml 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
   - 1.8.7
   - 1.9.2
-  - jruby
-  - rbx-head
+  - 1.9.3
+  - rbx
+  - rbx-2.0
   - ree
-  - ruby-head


### PR DESCRIPTION
- JRuby on travis right now has known issues so we recommend disabling it for some time
- rbx is not rbx-head any more, it is rbx-master in RVM and aliased as rbx
- rbx 2 preview is rbx-2.0, test against it
- we now provide 1.9.3(-preview1) on travis, test against it
