### PR TITLE
Issue #4: Make sure extra params go from Issues#create_issue to the http post

### DIFF
--- a/lib/seeclickfix/client/issues.rb
+++ b/lib/seeclickfix/client/issues.rb
@@ -75,7 +75,12 @@ module SeeClickFix
       # @example
       #   SeeClickFix.create_details("foo","41.3103725899427", "-72.9241595114853") http://seeclickfix.com/api/issues.xml
       def create_issue(summary, lat, lng, options={})
-        post("api/issues.json?issue[summary]=#{summary}&issue[lat]=#{lat}&issue[lng]=#{lng}")
+        summary_lat_lng = {
+          'issue[summary]' => summary,
+          'issue[lat]' => lat,
+          'issue[lng]' => lng
+        }
+        post("api/issues.json", options.merge(summary_lat_lng))
       end
 
     end

--- a/spec/seeclickfix/client/issues_spec.rb
+++ b/spec/seeclickfix/client/issues_spec.rb
@@ -36,13 +36,29 @@ describe SeeClickFix::Client::Issues do
 
   describe ".create_issue" do
     before do
-      stub_post("api/issues.json?issue[lat]=41.3103725899427&issue[lng]=-72.9241595114853&issue[summary]=foo").
+      stub_post("api/issues.json").
+        with(:body => {
+               'issue' => {
+                 'lat'=>'41.3103725899427',
+                 'lng'=>'-72.9241595114853',
+                 'summary'=>'foo',
+                 'description'=>'bar'
+               }
+             }).
         to_return(:status => 200, :body => fixture("create_issue.json"))
     end
 
     it "should create an issue" do
-      test = @client.create_issue("foo", "41.3103725899427", "-72.9241595114853")
-      a_post("api/issues.json?issue[lat]=41.3103725899427&issue[lng]=-72.9241595114853&issue[summary]=foo").should have_been_made
+      test = @client.create_issue("foo", "41.3103725899427", "-72.9241595114853", 'issue[description]' => 'bar')
+      a_post("api/issues.json").
+        with(:body => {
+               'issue' => {
+                 'lat'=>'41.3103725899427',
+                 'lng'=>'-72.9241595114853',
+                 'summary'=>'foo',
+                 'description'=>'bar'
+               }
+             }).should have_been_made
       test.first.status.should == "Open"
     end
   end


### PR DESCRIPTION
This gets it working, but I'm not sure about just passing extra params. Passing 'issues[description]' as a hash key, when the issue summary is elevated to a method parameter, feels weird.

I'm also not sure about the mocking style, but the method signature should come first.
